### PR TITLE
Add checkbox to enable publishing TwistStamped messages

### DIFF
--- a/include/joystick_panel/joystick_panel.hpp
+++ b/include/joystick_panel/joystick_panel.hpp
@@ -13,6 +13,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
+#include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 
 class QLineEdit;
@@ -61,13 +62,13 @@ namespace joystick_panel {
 
             /*
              * Uses the ROS2 publisher to publish a
-             * geometry_msgs/TwistStamped.msg.
+             * geometry_msgs/Twist.msg.
              */
             void publishVelocities();
 
             /*
              * The GUI's callback for updating the topic name at
-             * which to publish the TwistStamped msg.
+             * which to publish the Twist msg.
              */
             void updateTopic();
 
@@ -95,6 +96,12 @@ namespace joystick_panel {
              */
             void updateEnabled();
 
+            /*
+             * The GUI's callback for updating the stamped
+             * checkbox.
+             */
+            void updateStamped();
+
         protected:
             // Panel vars
             JoystickWidget* joystick_widget_;
@@ -103,11 +110,13 @@ namespace joystick_panel {
             QLineEdit* max_rotational_velocity_gui_;
             QCheckBox* return_to_zero_gui_;
             QCheckBox* enabled_gui_;
+            QCheckBox* stamped_gui_;
             std::string topic_;
 
             // ROS2 vars
             std::shared_ptr<rclcpp::Node> node_;
-            std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>> twist_publisher_;
+            std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::Twist>> twist_publisher_;
+            std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>> stamped_publisher_;
     };
 }
 

--- a/include/joystick_panel/joystick_panel.hpp
+++ b/include/joystick_panel/joystick_panel.hpp
@@ -13,7 +13,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
-#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 class QLineEdit;
 class QCheckBox;
@@ -61,13 +61,13 @@ namespace joystick_panel {
 
             /*
              * Uses the ROS2 publisher to publish a
-             * geometry_msgs/Twist.msg.
+             * geometry_msgs/TwistStamped.msg.
              */
             void publishVelocities();
 
             /*
              * The GUI's callback for updating the topic name at
-             * which to publish the Twist msg.
+             * which to publish the TwistStamped msg.
              */
             void updateTopic();
 
@@ -107,7 +107,7 @@ namespace joystick_panel {
 
             // ROS2 vars
             std::shared_ptr<rclcpp::Node> node_;
-            std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::Twist>> twist_publisher_;
+            std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>> twist_publisher_;
     };
 }
 

--- a/include/joystick_panel/joystick_widget.hpp
+++ b/include/joystick_panel/joystick_widget.hpp
@@ -57,6 +57,12 @@ namespace joystick_panel {
 
             /*
              * A public method for others building on this panel
+             * to set whether the topic is publishing stamped twist messages
+             */
+            bool getStamped();
+
+            /*
+             * A public method for others building on this panel
              * to set the maximum vels that the joystick widget can
              * reach set for publishing in the Twist msg.
              *
@@ -92,6 +98,14 @@ namespace joystick_panel {
              */
             void setEnabled(bool enabled);
 
+            /*
+             * A public method for others building on this panel
+             * to set whether the joystick widget publishes TwistStamped messages
+             *
+             * @param enabled whether or not the widget publishes stamped messages
+             */
+            void setStamped(bool enabled);
+
         protected Q_SLOTS:
             void calculateVelocities();
 
@@ -102,6 +116,7 @@ namespace joystick_panel {
             bool mouse_pressed_;
             bool return_to_zero_;
             bool enabled_;
+            bool stamped_;
             QPoint last_error_;
             float max_translational_velocity_; // m/s
             float max_rotational_velocity_; // rad/s

--- a/src/joystick_panel.cpp
+++ b/src/joystick_panel.cpp
@@ -151,9 +151,9 @@ namespace joystick_panel {
                 stamped_msg.twist.linear.x = msg.linear.x;
                 stamped_msg.twist.angular.z = msg.angular.z;
                 stamped_publisher_->publish(stamped_msg);
-            } else {
-                twist_publisher_->publish(msg);
             }
+
+            twist_publisher_->publish(msg);
         }
     }
 

--- a/src/joystick_panel.cpp
+++ b/src/joystick_panel.cpp
@@ -27,7 +27,7 @@ namespace joystick_panel {
         Panel(parent), topic_("/cmd_vel") {
         // Setup ROS2 functionality
         node_ = rclcpp::Node::make_shared("joystick_panel");
-        twist_publisher_ = node_->create_publisher<geometry_msgs::msg::Twist>(topic_, 10);
+        twist_publisher_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(topic_, 10);
 
         // Layout the panel
         joystick_widget_ = new JoystickWidget;
@@ -125,10 +125,11 @@ namespace joystick_panel {
 
     void JoystickPanel::publishVelocities() {
         if (joystick_widget_->getEnabled()) {
-            geometry_msgs::msg::Twist msg;
+            geometry_msgs::msg::TwistStamped msg;
+            msg.header.stamp = node_->get_clock()->now();
             auto vels = joystick_widget_->getVelocities();
-            msg.linear.x = std::get<0>(vels);
-            msg.angular.z = std::get<1>(vels);
+            msg.twist.linear.x = std::get<0>(vels);
+            msg.twist.angular.z = std::get<1>(vels);
             twist_publisher_->publish(msg);
         }
     }
@@ -171,7 +172,7 @@ namespace joystick_panel {
         }
 
         topic_ = topic;
-        twist_publisher_ = node_->create_publisher<geometry_msgs::msg::Twist>(topic_, 10);
+        twist_publisher_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(topic_, 10);
         return true;
     }
 }

--- a/src/joystick_widget.cpp
+++ b/src/joystick_widget.cpp
@@ -23,7 +23,7 @@ namespace joystick_panel {
     JoystickWidget::JoystickWidget(QWidget* parent) :
         QWidget(parent), max_translational_velocity_(5.0), max_rotational_velocity_(2.0),
         translational_velocity_(0.0), rotational_velocity_(0.0),
-        mouse_pressed_(false), return_to_zero_(true), enabled_(false) {
+        mouse_pressed_(false), return_to_zero_(true), enabled_(false), stamped_(false) {
         QTimer* calculation_timer = new QTimer(this);
         connect(calculation_timer, SIGNAL(timeout()), this, SLOT(calculateVelocities()));
         calculation_timer->start(10); // 0.01 seconds
@@ -204,5 +204,13 @@ namespace joystick_panel {
 
     void JoystickWidget::setEnabled(bool enabled) {
         enabled_ = enabled;
+    }
+
+    bool JoystickWidget::getStamped() {
+        return stamped_;
+    }
+
+    void JoystickWidget::setStamped(bool enabled) {
+        stamped_ = enabled;
     }
 }


### PR DESCRIPTION
This pull request adds a new checkbox that, when checked, publishes an additional geometry_msgs::msg::TwistStamped message on the current topic name + "_stamped"

This means that if the topic name is `/cmd_vel`, when the stamped checkbox is checked, an additional TwistStamped message is published on `/cmd_vel_stamped`